### PR TITLE
Add Capability to Ingest Tristan v2 Data (except spectral data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dependencies:
 -------------
 
 Python packages required: Anaconda 2021/5, matplotlib 3.0 & its required
-dependencies, python 3.7.3,  h5py, scipy >=v1.6.0. Will not work with older versions of anaconda3 and
+dependencies, python 3.10,  h5py, scipy >=v1.6.0. Will not work with older versions of anaconda3 and
 matplotlib 2.0 or older.
 
 To use the movie saving feature: ffmpeg & xterm.
@@ -31,7 +31,7 @@ Iseult should work on Windows, MacOS & Linux.
 
 To run Iseult on tigressdata or stellar vis nodes type the following:
 ```bash
-$ module load anaconda3/2021.5
+$ module load anaconda3/2023.3
 $ cd /path/to/Iseult/
 $ chmod +x ./iseult.py
 $ ./iseult.py

--- a/src/Numba2DHist.py
+++ b/src/Numba2DHist.py
@@ -50,11 +50,12 @@ def Fast2DWeightedHist(x1, x2, weights, min1, max1, bnum1, min2,max2, bnum2):
 if __name__ =='__main__':
     import numpy as np
     import matplotlib.pyplot as plt
-    import h5py
+    import data_loading
 
-    with h5py.File('output/prtl.tot.003', 'r') as f:
-        x = np.copy(f['xi'][:])
-        px = np.copy(f['ui'][:])
+    filepath = 'output/prtl.tot.003'
+    x = data_loading.load_dataset(filepath, 'xi', slice(None))
+    px = data_loading.load_dataset(filepath, 'ui', slice(None))
+
     #for k in range(10):
     #    x = np.append(x, x)
     #    px = np.append(px, px)

--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -79,11 +79,12 @@ def load_dataset(file_path: str | pathlib.Path, dataset_name: str, dataset_slice
         data_version = __detect_tristan_data_version(file)
 
         # Raise exception and exit if the version is wrong
-        if data_version != 1 or data_version != 2:
+        if data_version != 1 and data_version != 2:
             raise ValueError(f'Improper Tristan data version detected. Version detected is "{data_version}", should be "1" or "2".')
 
         # If the data is from Tristan v1 then return it and exit early
         if data_version == 1:
+            # might need to add a try/except here to catch KeyErrors
             return file[dataset_name][dataset_slice]
 
         # =====

--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -71,14 +71,14 @@ def __detect_tristan_data_version(file: h5py.File) -> int:
 # =============================================================================
 
 # =============================================================================
-def __insert_directory(path: pathlib.Path, inserted_directory: str, location: int = -1):
+def __insert_directory(path: pathlib.Path, inserted_directory: str, location: int = -1) -> pathlib.Path:
     path_list = list(pathlib.PurePath(path).parts)
     path_list.insert(location, inserted_directory)
     return pathlib.Path(pathlib.PurePath('').joinpath(*path_list))
 # =============================================================================
 
 # =============================================================================
-def __verify_file_path(file_path: pathlib.Path, dataset_name: str):
+def __verify_file_path(file_path: pathlib.Path, dataset_name: str) -> pathlib.Path | np.ndarray | int:
     unmodified_path = file_path
     # Check that the file exists. If not, try to handle the special cases before raising exception
     if file_path.exists():
@@ -117,7 +117,7 @@ def __verify_file_path(file_path: pathlib.Path, dataset_name: str):
 # =============================================================================
 
 # =============================================================================
-def __handle_tristan_v2(file_path: pathlib.Path, file: h5py.File, dataset_name: str, dataset_slice: tuple | slice):
+def __handle_tristan_v2(file_path: pathlib.Path, file: h5py.File, dataset_name: str, dataset_slice: tuple | slice) -> np.ndarray | int:
     # Make sure the dataset is properly mapped
     try:
         dataset_name = __v2_map[dataset_name]
@@ -147,7 +147,7 @@ def __handle_tristan_v2(file_path: pathlib.Path, file: h5py.File, dataset_name: 
 # =============================================================================
 
 # =============================================================================
-def load_dataset(file_path: str | pathlib.Path, dataset_name: str, dataset_slice: tuple | slice) -> np.array:
+def load_dataset(file_path: str | pathlib.Path, dataset_name: str, dataset_slice: tuple | slice) -> np.ndarray | int:
 
     # First check argument types
     assert isinstance(file_path, pathlib.Path) or isinstance(file_path, str)

--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import numpy as np
+import h5py
+import pathlib
+
+# define mapping between tristan v1 and v2 data, v1 data is considered the default
+__v2_map = {
+            # Parameters file
+            'c_omp':'plasma:c_omp',
+            'istep':'output:istep',
+            'me':'particles:m1',
+            'mi':'particles:m2',
+            'ppc0':'plasma:ppc0',
+            'qi':'particles:ch2',
+            'stride':'output:stride',
+            'time':'timestep', # or maybe timestep/plasma:c_omp
+            # Particles file
+            'ue':'u_1',
+            've':'v_1',
+            'we':'w_1',
+            'ui':'u_2',
+            'vi':'v_2',
+            'wi':'w_2',
+            'xe':'x_1',
+            'ye':'y_1',
+            'ze':'z_1',
+            'xi':'x_2',
+            'yi':'y_2',
+            'zi':'z_2',
+            'inde':'ind1',
+            'indi':'ind2',
+            'proce':'proc1',
+            'proci':'proc1',
+            # Fields file
+            'bx':'bx',
+            'by':'by',
+            'bz':'bz',
+            'ex':'ex',
+            'ey':'ey',
+            'ez':'ez',
+            'jx':'jx',
+            'jy':'jy',
+            'jz':'jz',
+            'dens':'compute_dens', # dens1 + dens2
+            'densi':'dens2',
+            }
+
+# =============================================================================
+def __detect_tristan_data_version(file: h5py.File) -> int:
+
+    # The fields to query were chosen only because they don't exist in the other version of Tristan
+    #  Files:  particles fields   spectra  paramater
+    v1_keys = ('che',    'densi', 'gamma', 'acool')
+    v2_keys = ('bx_1',   'dens1', 'ebins', 'algorithm:c')
+
+    if any(key in file for key in v1_keys):
+        return 1
+    elif any(key in file for key in v2_keys):
+        return 2
+    else:
+        raise ValueError('Data file format is not supported. If this is a data file from Tristan v1 or v2 please submit a bug report.')
+# =============================================================================
+
+# =============================================================================
+def load_dataset(file_path: str | pathlib.Path, dataset_name: str, dataset_slice: tuple | slice) -> np.array:
+
+    # First check argument types
+    assert isinstance(file_path, pathlib.Path) or isinstance(file_path, str)
+    assert isinstance(dataset_name, str)
+    assert isinstance(dataset_slice, tuple) or isinstance(dataset_slice, slice)
+    if isinstance(dataset_slice, tuple):
+        assert len(dataset_slice) <= 3
+        for element in dataset_slice:
+            assert isinstance(element, slice)
+
+    # open file
+    with h5py.File(file_path, 'r') as file:
+        # detect v1 or v2 data
+        data_version = __detect_tristan_data_version(file)
+
+        # Raise exception and exit if the version is wrong
+        if data_version != 1 or data_version != 2:
+            raise ValueError(f'Improper Tristan data version detected. Version detected is "{data_version}", should be "1" or "2".')
+
+        # If the data is from Tristan v1 then return it and exit early
+        if data_version == 1:
+            return file[dataset_name][dataset_slice]
+
+        # =====
+        # If the data is from Tristan v2 then perform whatever handling is needed. Note that at this point `data_version` must be 2
+        # =====
+
+        # Make sure the dataset is properly mapped
+        try:
+            dataset_name = __v2_map[dataset_name]
+        except KeyError:
+            raise KeyError(f'Requested dataset "{dataset_name}" is not mapped between Tristan v1 and v2 data. Please add appropriate mapping')
+
+        # check if this dataset requires additional handling, if not then return it and exit early
+        if dataset_name not in [__v2_map['dens']]:
+            return file[dataset_name][dataset_slice]
+
+        # Datasets that need special handling
+        if dataset_name == __v2_map['dens']:
+            return file['dens1'][dataset_slice] + file['dens2'][dataset_slice]
+        # elif dataset_name == __v2_map['?????']:
+        #     pass
+        else:
+            raise ValueError(f'Dataset "{dataset_name}" was indicated to require special handling but no clause was supplied to do that handling.')
+# =============================================================================

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2876,7 +2876,7 @@ class MainApp(Tk.Tk):
                     is_changed =[]
                     diff_list = []
                     for j in range(4):
-                        print(f'Logging for potential KeyError bug\n{i = }, {j = }, \n{home_view = }, \n{home_view[i] = }, \n{home_view[i][j] = }')
+                        print(f'Logging for potential KeyError bug\n{i = }, {j = }, \n{home_view = }, \n{home_view[i] = }')
                         num_changed = home_view[i][j]-cur_view[i][j] != 0.0
                         is_changed.append(num_changed)
                         if num_changed:

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2885,7 +2885,6 @@ class MainApp(Tk.Tk):
                     is_changed =[]
                     diff_list = []
                     for j in range(4):
-                        print(f'Logging for potential KeyError bug\n{i = }, {j = }, \n{home_view = }, \n{home_view[i] = }')
                         num_changed = home_view[i][j]-cur_view[i][j] != 0.0
                         is_changed.append(num_changed)
                         if num_changed:

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2122,20 +2122,6 @@ class MainApp(Tk.Tk):
         with open(cfgfile, 'w') as cfgFile:
             cfgFile.write(yaml.safe_dump(cfgDict))
 
-    def GenH5Dict(self):
-        '''Loads all of the files and then finds all of the keys in
-        the file to load data. Deprecated'''
-        for pkey in self.PathDict.keys():
-            with h5py.File(os.path.join(self.dirname,self.PathDict[pkey][0]), 'r') as f:
-                # Because dens is in both spect* files and flds* files,
-                for h5key in f.keys():
-                    if h5key == 'dens' and pkey == 'Spect':
-                        self.H5KeyDict['spect_dens'] = pkey
-                    else:
-                        self.H5KeyDict[h5key] = pkey
-
-        print(self.H5KeyDict)
-
     def ReloadPath(self):
         """ This function updates the current pathdictionary"""
         dirlist = os.listdir(self.dirname)
@@ -2449,7 +2435,7 @@ class MainApp(Tk.Tk):
 
     def LoadAllKeys(self):
         ''' A function that will find out will arrays need to be loaded for
-        to draw the graphs. Then it will save all the data necessaru to
+        to draw the graphs. Then it will save all the data necessary to
         If the time hasn't changed, it will only load new keys.'''
         # Make a dictionary that stores all of the keys we will need to load
         # to draw the graphs.

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2206,15 +2206,24 @@ class MainApp(Tk.Tk):
         param_re = re.compile(r'param.*')
 
         self.PathDict['Flds']= list(filter(f_re.match, os.listdir(self.dirname)))
+        if len(self.PathDict['Flds']) == 0:
+            self.PathDict['Flds']= list(filter(f_re.match, os.listdir(self.dirname+'/flds')))
         self.PathDict['Flds'].sort()
+
         self.PathDict['Prtl']= list(filter(prtl_re.match, os.listdir(self.dirname)))
+        if len(self.PathDict['Prtl']) == 0:
+            self.PathDict['Prtl']= list(filter(prtl_re.match, os.listdir(self.dirname+'/prtl')))
         self.PathDict['Prtl'].sort()
+
         self.PathDict['Spect']= list(filter(s_re.match, os.listdir(self.dirname)))
-        self.PathDict['Spect'].sort()
         if len(self.PathDict['Spect']) == 0:
             s_re = re.compile(r'spec.*')
             self.PathDict['Spect']= list(filter(s_re.match, os.listdir(self.dirname)))
-            self.PathDict['Spect'].sort()
+            if len(self.PathDict['Spect']) == 0 or (len(self.PathDict['Spect']) == 1 and self.PathDict['Spect'][0] == 'spec'):
+                self.PathDict['Spect']= list(filter(s_re.match, os.listdir(self.dirname+'/spec')))
+
+        self.PathDict['Spect'].sort()
+
         self.PathDict['Param']= list(filter(param_re.match, os.listdir(self.dirname)))
         self.PathDict['Param'].sort()
 

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2474,8 +2474,8 @@ class MainApp(Tk.Tk):
         # Check to make sure the 2DSlice is OK...
         # Grab c_omp & istep
         filepath = os.path.join(self.dirname,self.PathDict['Param'][self.TimeStep.value-1])
-        self.c_omp = data_loading.load_dataset(filepath, 'c_omp', slice(0))
-        self.istep = data_loading.load_dataset(filepath, 'istep', slice(0))
+        self.c_omp = data_loading.load_dataset(filepath, 'c_omp', slice(0,1))[0]
+        self.istep = data_loading.load_dataset(filepath, 'istep', slice(0,1))[0]
 
         # FIND THE SLICE
         filepath = os.path.join(self.dirname,self.PathDict['Flds'][self.TimeStep.value-1])
@@ -2566,13 +2566,13 @@ class MainApp(Tk.Tk):
                                 elif elm == 'ppc0':
                                     self.DataDict[elm] = np.nan
                                 elif elm == 'my':
-                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
-                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0))
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0,1))[0]
+                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0,1))[0]
                                     tmpSize = ((self.MaxYInd+1)*istep)//(my0-5)
                                     self.DataDict[elm] = np.ones(tmpSize)*my0
                                 elif elm == 'mx':
-                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
-                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0))
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0,1))[0]
+                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0,1))[0]
                                     tmpSize = ((self.MaxXInd+1)*istep)//(mx0-5)
                                     self.DataDict[elm] = np.ones(tmpSize)*mx0
                                 else:
@@ -2606,13 +2606,13 @@ class MainApp(Tk.Tk):
                                 elif elm == 'ppc0':
                                     self.DataDict[elm] = np.nan
                                 elif elm == 'my':
-                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
-                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0))
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0,1))[0]
+                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0,1))[0]
                                     tmpSize = ((self.MaxYInd+1)*istep)//(my0-5)
                                     self.DataDict[elm] = np.ones(tmpSize)*my0
                                 elif elm == 'mx':
-                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
-                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0))
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0,1))[0]
+                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0,1))[0]
                                     tmpSize = ((self.MaxXInd+1)*istep)//(mx0-5)
                                     self.DataDict[elm] = np.ones(tmpSize)*mx0
                                 else:
@@ -3461,7 +3461,7 @@ class MainApp(Tk.Tk):
             if abs_sigma == 0:
                 self.btheta = np.nan
             else:
-                self.btheta = self.c_omp = data_loading.load_dataset(filepath, 'btheta', slice(0))
+                self.btheta = self.c_omp = data_loading.load_dataset(filepath, 'btheta', slice(0,1))[0]
         except KeyError:
             self.btheta = np.nan
 

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -2200,12 +2200,10 @@ class MainApp(Tk.Tk):
         self.PathDict = {'Flds': [], 'Prtl': [], 'Param': [], 'Spect': []}
 
         # create a bunch of regular expressions used to search for files
-        f_re = re.compile('flds.tot.*')
-        prtl_re = re.compile('prtl.tot.*')
-        s_re = re.compile('spect.*')
-        param_re = re.compile('param.*')
-
-
+        f_re = re.compile(r'flds.tot.([\d\w\.]+)(?<!xdmf)$') # !(*.xdmf)
+        prtl_re = re.compile(r'prtl.tot.*')
+        s_re = re.compile(r'spect.*')
+        param_re = re.compile(r'param.*')
 
         self.PathDict['Flds']= list(filter(f_re.match, os.listdir(self.dirname)))
         self.PathDict['Flds'].sort()
@@ -2213,6 +2211,10 @@ class MainApp(Tk.Tk):
         self.PathDict['Prtl'].sort()
         self.PathDict['Spect']= list(filter(s_re.match, os.listdir(self.dirname)))
         self.PathDict['Spect'].sort()
+        if len(self.PathDict['Spect']) == 0:
+            s_re = re.compile(r'spec.*')
+            self.PathDict['Spect']= list(filter(s_re.match, os.listdir(self.dirname)))
+            self.PathDict['Spect'].sort()
         self.PathDict['Param']= list(filter(param_re.match, os.listdir(self.dirname)))
         self.PathDict['Param'].sort()
 
@@ -2464,7 +2466,7 @@ class MainApp(Tk.Tk):
         # Grab c_omp & istep
         filepath = os.path.join(self.dirname,self.PathDict['Param'][self.TimeStep.value-1])
         self.c_omp = data_loading.load_dataset(filepath, 'c_omp', slice(0))
-        self.c_omp = data_loading.load_dataset(filepath, 'istep', slice(0))
+        self.istep = data_loading.load_dataset(filepath, 'istep', slice(0))
 
         # FIND THE SLICE
         filepath = os.path.join(self.dirname,self.PathDict['Flds'][self.TimeStep.value-1])
@@ -2874,6 +2876,7 @@ class MainApp(Tk.Tk):
                     is_changed =[]
                     diff_list = []
                     for j in range(4):
+                        print(f'Logging for potential KeyError bug\n{i = }, {j = }, \n{home_view = }, \n{home_view[i] = }, \n{home_view[i][j] = }')
                         num_changed = home_view[i][j]-cur_view[i][j] != 0.0
                         is_changed.append(num_changed)
                         if num_changed:
@@ -3444,7 +3447,8 @@ class MainApp(Tk.Tk):
                 '''
             # Normalize by b0
             filepath = os.path.join(self.dirname,self.PathDict['Param'][0])
-            abs_sigma = np.abs(data_loading.load_dataset(filepath, 'sigma', slice(0)))
+            abs_sigma = np.abs(data_loading.load_dataset(filepath, 'sigma', slice(None)))[0]
+
             if abs_sigma == 0:
                 self.btheta = np.nan
             else:

--- a/src/main_app.py
+++ b/src/main_app.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 import re # regular expressions
 import os, sys # Used to make the code portable
-import h5py # Allows us the read the data files
+import data_loading # Allows us the read the data files
 import time, string, io
 from PIL import Image
 import matplotlib
@@ -2462,19 +2462,17 @@ class MainApp(Tk.Tk):
 
         # Check to make sure the 2DSlice is OK...
         # Grab c_omp & istep
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Param'][self.TimeStep.value-1]), 'r') as f:
-            self.c_omp = f['c_omp'][0]
-            self.istep = f['istep'][0]
+        filepath = os.path.join(self.dirname,self.PathDict['Param'][self.TimeStep.value-1])
+        self.c_omp = data_loading.load_dataset(filepath, 'c_omp', slice(0))
+        self.c_omp = data_loading.load_dataset(filepath, 'istep', slice(0))
 
         # FIND THE SLICE
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Flds'][self.TimeStep.value-1]), 'r') as f:
-            self.MaxZInd = f['bx'].shape[0]-1
-            self.MaxYInd = f['bx'].shape[1]-1
-            self.MaxXInd = f['bx'].shape[2]-1
+        filepath = os.path.join(self.dirname,self.PathDict['Flds'][self.TimeStep.value-1])
+        bx_shape = data_loading.load_dataset(filepath, 'bx', slice(None,None,None)).shape
+        self.MaxZInd, self.MaxYInd, self.MaxXInd  = np.array(bx_shape) - 1
 
-            self.ySlice = int(np.around(self.MainParamDict['ySlice']*self.MaxYInd))
-            self.zSlice = int(np.around(self.MainParamDict['zSlice']*self.MaxZInd))
-
+        self.ySlice = int(np.around(self.MainParamDict['ySlice']*self.MaxYInd))
+        self.zSlice = int(np.around(self.MainParamDict['zSlice']*self.MaxZInd))
 
         # See if we are in a new Directory
         if self.NewDirectory:
@@ -2537,43 +2535,37 @@ class MainApp(Tk.Tk):
                     if tmplist2[i] in self.DataDict.keys():
                         tmplist.remove(tmplist2[i])
                 # Now iterate over each path key and create a datadictionary
+                filepath = os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1])
                 if len(tmplist)> 0:
-                    if pkey == 'Prtl': # we load particle arrays with a stride because they are very expensive
-                        with h5py.File(os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1]), 'r') as f:
-                            for elm in tmplist:
-                                try:
-                                    # Load all the keys
-                                    self.DataDict[elm] = f[elm][::self.MainParamDict['PrtlStride']]
-
-                                except KeyError:
-                                    raise
+                    if pkey =='Prtl': # we load particle arrays with a stride because they are expensive
+                        for elm in tmplist:
+                            self.DataDict[elm] = data_loading.load_dataset(filepath, elm, slice(None, None, self.MainParamDict['PrtlStride']))
                     else:
-                        with h5py.File(os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1]), 'r') as f:
-                            for elm in tmplist:
-                                try:
-                                    # Load all the keys
-                                    if elm == 'spect_dens':
-                                        self.DataDict[elm] = f['dens'][:]
-                                    else:
-                                        self.DataDict[elm] = f[elm][:]
-
-                                except KeyError:
-                                    if elm == 'sizex':
-                                        self.DataDict[elm] = 1
-                                    elif elm == 'c':
-                                        self.DataDict[elm]= 0.45
-                                    elif elm == 'ppc0':
-                                        self.DataDict[elm] = np.nan
-                                    elif elm == 'my':
-                                        tmpSize = ((self.MaxYInd+1)*f['istep'][0])//(f['my0'][0]-5)
-                                        self.DataDict[elm] = np.ones(tmpSize)*(f['my0'][0])
-                                    elif elm == 'mx':
-                                        tmpSize = ((self.MaxXInd+1)*f['istep'][0])//(f['mx0'][0]-5)
-                                        self.DataDict[elm] = np.ones(tmpSize)*(f['mx0'][0])
-
-
-                                    else:
-                                        raise
+                        for elm in tmplist:
+                            try:
+                                if elm == 'spect_dens':
+                                    self.DataDict[elm] = data_loading.load_dataset(filepath, 'dens', slice(None))
+                                else:
+                                    self.DataDict[elm] = data_loading.load_dataset(filepath, elm, slice(None))
+                            except KeyError:
+                                if elm == 'sizex':
+                                    self.DataDict[elm] = 1
+                                elif elm == 'c':
+                                    self.DataDict[elm]= 0.45
+                                elif elm == 'ppc0':
+                                    self.DataDict[elm] = np.nan
+                                elif elm == 'my':
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
+                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0))
+                                    tmpSize = ((self.MaxYInd+1)*istep)//(my0-5)
+                                    self.DataDict[elm] = np.ones(tmpSize)*my0
+                                elif elm == 'mx':
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
+                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0))
+                                    tmpSize = ((self.MaxXInd+1)*istep)//(mx0-5)
+                                    self.DataDict[elm] = np.ones(tmpSize)*mx0
+                                else:
+                                    raise
 
             self.timestep_queue.append(self.TimeStep.value)
 
@@ -2583,42 +2575,37 @@ class MainApp(Tk.Tk):
             for pkey in self.ToLoad.keys():
                 tmplist = list(set(self.ToLoad[pkey])) # get rid of duplicate keys
                 # Load the file
+                filepath = os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1])
                 if len(tmplist)> 0:
                     if pkey =='Prtl': # we load particle arrays with a stride because they are expensive
-                        with h5py.File(os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1]), 'r') as f:
-                            for elm in tmplist:
-                                try:
-                                    # Load all the key
-                                    self.DataDict[elm] = f[elm][::self.MainParamDict['PrtlStride']]
-
-                                except KeyError:
-                                    raise
+                        for elm in tmplist:
+                            self.DataDict[elm] = data_loading.load_dataset(filepath, elm, slice(None, None, self.MainParamDict['PrtlStride']))
                     else:
-                        with h5py.File(os.path.join(self.dirname,self.PathDict[pkey][self.TimeStep.value-1]), 'r') as f:
-                            for elm in tmplist:
-                                try:
-                                    # Load all the keys
-                                    if elm == 'spect_dens':
-                                        self.DataDict[elm] = f['dens'][:]
-                                    else:
-                                        self.DataDict[elm] = f[elm][:]
-
-                                except KeyError:
-                                    if elm == 'sizex':
-                                        self.DataDict[elm] = 1
-                                    elif elm == 'c':
-                                        self.DataDict[elm]= 0.45
-                                    elif elm == 'ppc0':
-                                        self.DataDict[elm] = np.nan
-                                    elif elm == 'my':
-                                        tmpSize = ((self.MaxYInd+1)*f['istep'][0])//(f['my0'][0]-5)
-                                        self.DataDict[elm] = np.ones(tmpSize)*(f['my0'][0])
-                                    elif elm == 'mx':
-                                        tmpSize = ((self.MaxXInd+1)*f['istep'][0])//(f['mx0'][0]-5)
-                                        self.DataDict[elm] = np.ones(tmpSize)*(f['mx0'][0])
-
-                                    else:
-                                        raise
+                        for elm in tmplist:
+                            try:
+                                if elm == 'spect_dens':
+                                    self.DataDict[elm] = data_loading.load_dataset(filepath, 'dens', slice(None))
+                                else:
+                                    self.DataDict[elm] = data_loading.load_dataset(filepath, elm, slice(None))
+                            except KeyError:
+                                if elm == 'sizex':
+                                    self.DataDict[elm] = 1
+                                elif elm == 'c':
+                                    self.DataDict[elm]= 0.45
+                                elif elm == 'ppc0':
+                                    self.DataDict[elm] = np.nan
+                                elif elm == 'my':
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
+                                    my0   = data_loading.load_dataset(filepath, 'my0', slice(0))
+                                    tmpSize = ((self.MaxYInd+1)*istep)//(my0-5)
+                                    self.DataDict[elm] = np.ones(tmpSize)*my0
+                                elif elm == 'mx':
+                                    istep = data_loading.load_dataset(filepath, 'istep', slice(0))
+                                    mx0   = data_loading.load_dataset(filepath, 'mx0', slice(0))
+                                    tmpSize = ((self.MaxXInd+1)*istep)//(mx0-5)
+                                    self.DataDict[elm] = np.ones(tmpSize)*mx0
+                                else:
+                                    raise
 
             # don't keep more than 30 time steps in memory because of RAM issues
             if len(self.timestep_visited)>30:
@@ -3419,79 +3406,84 @@ class MainApp(Tk.Tk):
 
         # First load the first field file to find the initial size of the
         # box in the x direction, and find the initial field values
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Param'][0]), 'r') as f:
-            # Find out what sigma is
-            try:
-                ''' Obviously the most correct way to do this to to calculate b0 from sigma.
-                This is proving more difficult that I thought it would be, so I am calculating it
-                as Jaehong did.
 
-                sigma = f['sigma'][0]
-                gamma0 = f['gamma0'][0]
-                c = f['c'][0]
-                btheta = f['btheta'][0]
-                bphi = f['bphi'][0]
+        # Find out what sigma is
+        try:
+            ''' Obviously the most correct way to do this to to calculate b0 from sigma.
+            This is proving more difficult that I thought it would be, so I am calculating it
+            as Jaehong did.
 
-                ppc0 = f['ppc0'][0]
-                mi = f['mi'][0]
-                me = f['me'][0]
-                print mi, c, ppc0
-                if gamma0 <1:
-                    beta0 = gamma0
-                    gamma0 = 1/np.sqrt(1-gamma0**2)
-                else:
-                    beta0=np.sqrt(1-gamma0**(-2))
+            sigma = f['sigma'][0]
+            gamma0 = f['gamma0'][0]
+            c = f['c'][0]
+            btheta = f['btheta'][0]
+            bphi = f['bphi'][0]
 
-
-                if sigma <= 1E-10:
-                    self.b0 = 1.0
-                    self.e0 = 1.0
-                else:
-                    # b0 in the upstream frame
-                    self.b0 = np.sqrt(gamma0*ppc0*.5*c**2*(mi+me)*sigma)
-                    # Translate to the downstream frame
-                    b_x = self.b0*np.cos(btheta)*np.cos(bphi)
-                    b_y = self.b0*np.sin(btheta)*np.cos(bphi)
-                    b_z = self.b0*np.sin(btheta)*np.cos(bphi)
-                    print 'sigma b0', self.b0
-                    '''
-                    # Normalize by b0
-                if np.abs(f['sigma'][0])==0:
-                    self.btheta = np.nan
-                else:
-                    self.btheta = f['btheta'][0]
-            except KeyError:
-                self.btheta = np.nan
+            ppc0 = f['ppc0'][0]
+            mi = f['mi'][0]
+            me = f['me'][0]
+            print mi, c, ppc0
+            if gamma0 <1:
+                beta0 = gamma0
+                gamma0 = 1/np.sqrt(1-gamma0**2)
+            else:
+                beta0=np.sqrt(1-gamma0**(-2))
 
 
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Flds'][0]), 'r') as f:
-            by = f['by'][:]
-            nxf0 = by.shape[1]
-            if np.isnan(self.btheta):
+            if sigma <= 1E-10:
                 self.b0 = 1.0
                 self.e0 = 1.0
             else:
-                # Normalize by b0
-                print(np.shape((f['bx'])))
-                self.bx0 = f['bx'][0,-1,-10]
-                self.by0 = by[0,-1,-10]
-                self.bz0 = f['bz'][0,-1,-10]
-                self.b0 = np.sqrt(self.bx0**2+self.by0**2+self.bz0**2)
-                self.ex0 = f['ex'][0,-1,-2]
-                self.ey0 = f['ey'][0,-1,-2]
-                self.ez0 = f['ez'][0,-1,-2]
-                self.e0 = np.sqrt(self.ex0**2+self.ey0**2+self.ez0**2)
+                # b0 in the upstream frame
+                self.b0 = np.sqrt(gamma0*ppc0*.5*c**2*(mi+me)*sigma)
+                # Translate to the downstream frame
+                b_x = self.b0*np.cos(btheta)*np.cos(bphi)
+                b_y = self.b0*np.sin(btheta)*np.cos(bphi)
+                b_z = self.b0*np.sin(btheta)*np.cos(bphi)
+                print 'sigma b0', self.b0
+                '''
+            # Normalize by b0
+            filepath = os.path.join(self.dirname,self.PathDict['Param'][0])
+            abs_sigma = np.abs(data_loading.load_dataset(filepath, 'sigma', slice(0)))
+            if abs_sigma == 0:
+                self.btheta = np.nan
+            else:
+                self.btheta = self.c_omp = data_loading.load_dataset(filepath, 'btheta', slice(0))
+        except KeyError:
+            self.btheta = np.nan
+
+        filepath = os.path.join(self.dirname,self.PathDict['Flds'][0])
+        by = data_loading.load_dataset(filepath, 'by', slice(None))
+        nxf0 = by.shape[1]
+        if np.isnan(self.btheta):
+            self.b0 = 1.0
+            self.e0 = 1.0
+        else:
+            # Normalize by b0
+            bx = data_loading.load_dataset(filepath, 'bx', slice(None))
+            print(np.shape(bx))
+            b_slice = (slice(0,1),slice(-1,None),slice(-10,-9))
+            self.bx0 = bx[0,-1,-10]
+            self.by0 = by[0,-1,-10]
+            self.bz0 = data_loading.load_dataset(filepath, 'bz', b_slice)[0,0,0]
+            self.b0 = np.sqrt(self.bx0**2+self.by0**2+self.bz0**2)
+            e_slice = (slice(0,1), slice(-1,None), slice(-2,-1))
+            self.ex0 = data_loading.load_dataset(filepath, 'ex', e_slice)[0,0,0]
+            self.ey0 = data_loading.load_dataset(filepath, 'ey', e_slice)[0,0,0]
+            self.ez0 = data_loading.load_dataset(filepath, 'ez', e_slice)[0,0,0]
+            self.e0 = np.sqrt(self.ex0**2+self.ey0**2+self.ez0**2)
 
         # Load the final time step to find the shock's location at the end.
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Flds'][-1]), 'r') as f:
-            dens_arr =np.copy(f['dens'][0,:,:])
+        filepath = os.path.join(self.dirname,self.PathDict['Flds'][-1])
+        dens_slice = (slice(0,1), slice(None), slice(None))
+        dens_arr = data_loading.load_dataset(filepath, 'dens', dens_slice)[0,:,:]
 
-        with h5py.File(os.path.join(self.dirname,self.PathDict['Param'][-1]), 'r') as f:
-            # I use this file to get the final time, the istep, interval, and c_omp
-            final_time = f['time'][0]
-            istep = f['istep'][0]
-            interval = f['interval'][0]
-            c_omp = f['c_omp'][0]
+        # I use this file to get the final time, the istep, interval, and c_omp
+        filepath = os.path.join(self.dirname,self.PathDict['Param'][-1])
+        final_time = data_loading.load_dataset(filepath, 'time',     slice(None))[0]
+        istep      = data_loading.load_dataset(filepath, 'istep',    slice(None))[0]
+        interval   = data_loading.load_dataset(filepath, 'interval', slice(None))[0]
+        c_omp      = data_loading.load_dataset(filepath, 'c_omp',    slice(None))[0]
 
         # Find out where the shock is at the last time step.
         jstart = int(min(10*c_omp/istep, nxf0))

--- a/src/tristanSim.py
+++ b/src/tristanSim.py
@@ -1,5 +1,6 @@
 import re, sys, os, h5py
 import numpy as np
+import data_loading
 
 
 class cachedProperty(object):
@@ -46,7 +47,7 @@ class PicSim(object):
                     tmpStr += elm +'.'
                 tmpStr += self._fnum[0]
                 with h5py.File(os.path.join(self.dir, tmpStr), 'r') as f:
-                    self._outputFileH5Keys.append([key for key in f.keys()])
+                    self._outputFileH5Keys.append(list(f.keys()))
             # Build an key to h5 file dictionary, and a h5 file to key dictionary
             self._output = [OutputPoint(self, n=x) for x in self.getFileNums()]
             for fkey in self._outputFileKey:
@@ -245,11 +246,11 @@ class h5Wrapper(object):
     def __getattribute__(self, name):
         if object.__getattribute__(self, name) is None:
             if name in self.__h5Keys:
-                with h5py.File(self._fname, 'r') as f:
-                    if np.sum([x for x in f[name].shape])!= 1:
-                        setattr(self, name, f[name][:])
-                    else:
-                        setattr(self, name, f[name][0])
+                data = data_loading.load_data(self._fname, name, slice(None))
+                if np.sum([x for x in data.shape]) != 1:
+                    setattr(self, name, data)
+                else:
+                    setattr(self, name, data[0])
         return object.__getattribute__(self, name)
 
     def keys(self):

--- a/src/tristan_sim.py
+++ b/src/tristan_sim.py
@@ -1,6 +1,6 @@
 import re, sys, os, h5py
 import numpy as np
-
+import data_loading
 
 class cachedProperty(object):
     """
@@ -46,7 +46,7 @@ class TristanSim(object):
                     tmpStr += elm +'.'
                 tmpStr += self._fnum[0]
                 with h5py.File(os.path.join(self.dir, tmpStr), 'r') as f:
-                    self._outputFileH5Keys.append([key for key in f.keys()])
+                    self._outputFileH5Keys.append(list(f.keys()))
             # Build an key to h5 file dictionary, and a h5 file to key dictionary
             self._output = [OutputPoint(self, n=x) for x in self.getFileNums()]
             for fkey in self._outputFileKey:
@@ -204,14 +204,13 @@ class h5Wrapper(object):
         if object.__getattribute__(self, name) is None:
             if name in self.__h5Keys:
                 if self._fname.split('.')[0] == 'prtl':
-                    with h5py.File(self._fname, 'r') as f:
-                        setattr(self, name, f[name][::self.stride])
+                    setattr(self, name, data_loading.load_data(self._fname, name, slice(None,None,self.stride)))
                 else:
-                    with h5py.File(self._fname, 'r') as f:
-                        if np.sum([x for x in f[name].shape])!= 1:
-                            setattr(self, name, f[name][:])
-                        else:
-                            setattr(self, name, f[name][0])
+                    data = data_loading.load_data(self._fname, name, slice(None))
+                    if np.sum([x for x in data.shape]) != 1:
+                        setattr(self, name, data)
+                    else:
+                        setattr(self, name, data[0])
 
         return object.__getattribute__(self, name)
 


### PR DESCRIPTION
pyth## Summary

Enable Iseult to read in data from Tristan v1 or v2. This primarily involves implementing a set of new functions for reading data from the HDF5 files. If the data is from Tristan v1 then the data is simply returned as is, if it's from v2 then the data is transformed to look like Tristan v1 data and transformed. Note that _does not support_ loading spectral data from Tristan v2, that capability will be added later.

Currently I have only verified that it still loads Tristan v1 data properly. Verifying that Tristan v2 data works is next but I wanted to make this available now for people to test the changes with Tristan v1 data.

## Notes

- This bumps the required python version to at least 3.11 (anaconda3/2023.9 on Stellar) due to the use of unions (`|`) in type hinting. Versions past this **will not work** due to a change to how matplotlib formats some of its protected members that Iseult uses.