### PR TITLE
Fix 2D User Defined Plots (issue #13)

### DIFF
--- a/src/energy_panel.py
+++ b/src/energy_panel.py
@@ -130,9 +130,9 @@ class EnergyPanel:
 
         if self.GetPlotParam('masked'):
             zval = ma.masked_array(self.hist2d[0])
-            zval[zval == 0] = ma.masked
+            zval[zval <= 0] = ma.masked
             zval *= float(zval.max())**(-1)
-            tmplist = [zval[not zval.mask].min(), zval.max()]
+            tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
         else:
             zval = np.copy(self.hist2d[0])
             zval[zval==0] = 0.5

--- a/src/energy_panel.py
+++ b/src/energy_panel.py
@@ -132,7 +132,7 @@ class EnergyPanel:
             zval = ma.masked_array(self.hist2d[0])
             zval[zval == 0] = ma.masked
             zval *= float(zval.max())**(-1)
-            tmplist = [zval[~zval.mask].min(), zval.max()]
+            tmplist = [zval[not zval.mask].min(), zval.max()]
         else:
             zval = np.copy(self.hist2d[0])
             zval[zval==0] = 0.5

--- a/src/energy_plots.py
+++ b/src/energy_plots.py
@@ -213,7 +213,7 @@ class EnergyPanel:
                 zval = ma.masked_array(self.hist2d[0])
                 zval[zval == 0] = ma.masked
                 zval *= float(zval.max())**(-1)
-                tmplist = [zval[~zval.mask].min(), zval.max()]
+                tmplist = [zval[not zval.mask].min(), zval.max()]
             else:
                 zval = np.copy(self.hist2d[0])
                 zval[zval==0] = 0.5

--- a/src/energy_plots.py
+++ b/src/energy_plots.py
@@ -211,9 +211,9 @@ class EnergyPanel:
 
             if self.GetPlotParam('masked'):
                 zval = ma.masked_array(self.hist2d[0])
-                zval[zval == 0] = ma.masked
+                zval[zval <= 0] = ma.masked
                 zval *= float(zval.max())**(-1)
-                tmplist = [zval[not zval.mask].min(), zval.max()]
+                tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
             else:
                 zval = np.copy(self.hist2d[0])
                 zval[zval==0] = 0.5

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -1291,7 +1291,7 @@ class FieldSettings(Tk.Toplevel):
         if self.parent.GetPlotParam('normalize_fields') == self.NormFieldVar.get():
             pass
         else:
-            if ~self.parent.GetPlotParam('twoD'):
+            if not self.parent.GetPlotParam('twoD'):
                 tmplblstr = self.parent.GetPlotParam('yaxis_label')[self.FieldTypeVar.get()]
                 if self.NormFieldVar.get():
                     if self.parent.GetPlotParam('field_type') ==0:
@@ -1395,7 +1395,7 @@ class FieldSettings(Tk.Toplevel):
                 self.parent.SetPlotParam('show_x', False, update_plot = False)
                 self.parent.SetPlotParam('show_y', False, update_plot = False)
                 self.parent.SetPlotParam('show_z', False, update_plot = False)
-                if ~self.parent.GetPlotParam('twoD'):
+                if not self.parent.GetPlotParam('twoD'):
                     self.parent.linex[0].set_visible(False)
                     self.parent.anx.set_visible(False)
                     self.parent.liney[0].set_visible(False)
@@ -1418,7 +1418,8 @@ class FieldSettings(Tk.Toplevel):
                 self.parent.SetPlotParam('show_x', False, update_plot = False)
                 self.parent.SetPlotParam('show_y', False, update_plot = False)
                 self.parent.SetPlotParam('show_z', False, update_plot = False)
-                if ~self.parent.GetPlotParam('twoD'):
+                if not self.parent.GetPlotParam('twoD'):
+                    print(f"{self.parent.GetPlotParam('twoD') = }")
                     self.parent.linex[0].set_visible(False)
                     self.parent.anx.set_visible(False)
                     self.parent.liney[0].set_visible(False)
@@ -1608,7 +1609,7 @@ class UserDefSettings(Tk.Toplevel):
         tmplist2.append(tmplist)
 
         self.subplot.SetPlotParam('1D_label',tmplist2, update_plot =False)
-        if ~self.subplot.GetPlotParam('twoD'):
+        if not self.subplot.GetPlotParam('twoD'):
             self.subplot.axes.set_ylabel(self.subplot.GetPlotParam('yaxis_label')[3])
             self.subplot.anx.set_text(self.subplot.GetPlotParam('1D_label')[3][0])
             self.subplot.any.set_text(self.subplot.GetPlotParam('1D_label')[3][1])

--- a/src/mag_panel.py
+++ b/src/mag_panel.py
@@ -97,7 +97,7 @@ class BPanel:
 
 
         if self.GetPlotParam('mag_plot_type') == 1: # Set f to deltaB/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$|\delta B|/B_0$'
                 self.ann_label = r'$|\delta B|/B_0$'
             else:
@@ -115,7 +115,7 @@ class BPanel:
 
 
         if self.GetPlotParam('mag_plot_type') == 2: # Set f to deltaB_perp/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$|\delta B_\perp|/B_0$'
                 self.ann_label = r'$|\delta B_\perp|/B_0$'
             else:
@@ -138,7 +138,7 @@ class BPanel:
 
 
         if self.GetPlotParam('mag_plot_type') == 3: # Set f to deltaB_para/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$\delta B_\parallel/B_0$'
                 self.ann_label = r'$\delta B_\parallel/B_0$'
             else:

--- a/src/mag_plots.py
+++ b/src/mag_plots.py
@@ -137,7 +137,7 @@ class BPanel:
         #        self.parent.DataDict['xi_perpmin_max'+str(self.ind)] = list(self.min_max)
 
         if self.GetPlotParam('mag_plot_type') == 1: # Set f to deltaB/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$|\delta B|/B_0$'
                 self.ann_label = r'$|\delta B|/B_0$'
             else:
@@ -155,7 +155,7 @@ class BPanel:
 
 
         if self.GetPlotParam('mag_plot_type') == 2: # Set f to deltaB_perp/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$|\delta B_\perp|/B_0$'
                 self.ann_label = r'$|\delta B_\perp|/B_0$'
             else:
@@ -176,7 +176,7 @@ class BPanel:
                 self.parent.DataDict['deltaB_perp'] = self.f
 
         if self.GetPlotParam('mag_plot_type') == 3: # Set f to deltaB_para/B0
-            if ~np.isnan(self.parent.btheta):
+            if not np.isnan(self.parent.btheta):
                 self.ylabel = r'$\delta B_\parallel/B_0$'
                 self.ann_label = r'$\delta B_\parallel/B_0$'
             else:

--- a/src/phase_panel.py
+++ b/src/phase_panel.py
@@ -214,7 +214,7 @@ class PhasePanel:
                         inRange *= energy <= self.GetPlotParam('E_max')
                 elif self.GetPlotParam('set_E_max'):
                     inRange = energy <= self.GetPlotParam('E_max')
-                inRange *= ~nan_ind
+                inRange *= not nan_ind
                 if self.GetPlotParam('weighted'):
                     self.hist2d = Fast2DWeightedHist(self.y_values[inRange], self.x_values[inRange], self.weights[inRange], self.pmin,self.pmax, self.GetPlotParam('pbins'), self.xmin,self.xmax, self.GetPlotParam('xbins')), [self.pmin, self.pmax], [self.xmin, self.xmax]
 
@@ -231,7 +231,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[~zval.mask].min(), zval.max()]
+                    tmplist = [zval[not zval.mask].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5
@@ -330,7 +330,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[~zval.mask].min(), zval.max()]
+                    tmplist = [zval[not zval.mask].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5

--- a/src/phase_panel.py
+++ b/src/phase_panel.py
@@ -214,7 +214,7 @@ class PhasePanel:
                         inRange *= energy <= self.GetPlotParam('E_max')
                 elif self.GetPlotParam('set_E_max'):
                     inRange = energy <= self.GetPlotParam('E_max')
-                inRange *= not nan_ind
+                inRange *= np.logical_not(nan_ind)
                 if self.GetPlotParam('weighted'):
                     self.hist2d = Fast2DWeightedHist(self.y_values[inRange], self.x_values[inRange], self.weights[inRange], self.pmin,self.pmax, self.GetPlotParam('pbins'), self.xmin,self.xmax, self.GetPlotParam('xbins')), [self.pmin, self.pmax], [self.xmin, self.xmax]
 
@@ -229,9 +229,9 @@ class PhasePanel:
             try:
                 if self.GetPlotParam('masked'):
                     zval = ma.masked_array(self.hist2d[0])
-                    zval[zval == 0] = ma.masked
+                    zval[zval <= 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[not zval.mask].min(), zval.max()]
+                    tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5
@@ -330,7 +330,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[not zval.mask].min(), zval.max()]
+                    tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5

--- a/src/phase_plots.py
+++ b/src/phase_plots.py
@@ -323,7 +323,7 @@ class PhasePanel:
                         inRange *= energy <= self.GetPlotParam('E_max')
                 elif self.GetPlotParam('set_E_max'):
                     inRange = energy <= self.GetPlotParam('E_max')
-                inRange *= not nan_ind
+                inRange *= np.logical_not(nan_ind)
                 if self.GetPlotParam('weighted'):
                     self.hist2d = Fast2DWeightedHist(self.y_values[inRange], self.x_values[inRange], self.weights[inRange], self.pmin,self.pmax, self.GetPlotParam('pbins'), self.xmin,self.xmax, self.GetPlotParam('xbins')), [self.pmin, self.pmax], [self.xmin, self.xmax]
 
@@ -340,7 +340,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[not zval.mask].min(), zval.max()]
+                    tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5
@@ -439,7 +439,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[not zval.mask].min(), zval.max()]
+                    tmplist = [zval[np.logical_not(zval.mask)].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5

--- a/src/phase_plots.py
+++ b/src/phase_plots.py
@@ -323,7 +323,7 @@ class PhasePanel:
                         inRange *= energy <= self.GetPlotParam('E_max')
                 elif self.GetPlotParam('set_E_max'):
                     inRange = energy <= self.GetPlotParam('E_max')
-                inRange *= ~nan_ind
+                inRange *= not nan_ind
                 if self.GetPlotParam('weighted'):
                     self.hist2d = Fast2DWeightedHist(self.y_values[inRange], self.x_values[inRange], self.weights[inRange], self.pmin,self.pmax, self.GetPlotParam('pbins'), self.xmin,self.xmax, self.GetPlotParam('xbins')), [self.pmin, self.pmax], [self.xmin, self.xmax]
 
@@ -340,7 +340,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[~zval.mask].min(), zval.max()]
+                    tmplist = [zval[not zval.mask].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5
@@ -439,7 +439,7 @@ class PhasePanel:
                     zval = ma.masked_array(self.hist2d[0])
                     zval[zval == 0] = ma.masked
                     zval *= float(zval.max())**(-1)
-                    tmplist = [zval[~zval.mask].min(), zval.max()]
+                    tmplist = [zval[not zval.mask].min(), zval.max()]
                 else:
                     zval = np.copy(self.hist2d[0])
                     zval[zval==0] = 0.5


### PR DESCRIPTION
# Summary

It appears that the issue was the usage of the bitwise not operator (`~`) in a handful of places where logical not operator (`not`) should have been used. In addition to the user-defined plots issue this might clear up some other issues or odd behavior in other places that were affected by this issue.

closes #13 

### Instructions for Getting This Branch
```bash
$ git clone git@github.com:bcaddy/Iseult.git bobs-iseult
$ cd bobs-iseult
$ git checkout --track origin/master-iss13
```