### PR TITLE
Add Magnetic Streamlines to Field and Density Plots

### DIFF
--- a/src/density_plots.py
+++ b/src/density_plots.py
@@ -84,6 +84,9 @@ class DensPanel:
         if self.GetPlotParam('dens_type') >0: # Load the ion density
             self.arrs_needed.append('densi')
 
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
+            streamlines.add_streamline_plot_keys(self)
+
         return self.arrs_needed
     def LoadData(self):
         ''' A Helper function that loads the data for the plot'''

--- a/src/density_plots.py
+++ b/src/density_plots.py
@@ -10,6 +10,7 @@ import matplotlib.colors as mcolors
 import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
 from matplotlib.ticker import FuncFormatter
+import streamlines
 
 class DensPanel:
     # A dictionary of all of the parameters for this plot with the default parameters
@@ -37,6 +38,8 @@ class DensPanel:
                        'cmap': 'None', # If cmap is none, the plot will inherit the parent's cmap
                        'show_cpu_domains': False, # plots lines showing how the CPUs are divvying up the computational region
                        'face_color': 'gainsboro'}
+
+    streamlines.add_streamline_params(plot_param_dict)
 
     gradient =  np.linspace(0, 1, 256)# A way to make the colorbar display better
     gradient = np.vstack((gradient, gradient))
@@ -410,6 +413,8 @@ class DensPanel:
             self.axes.set_xlabel(r'$x\ [c/\omega_{\rm pe}]$', labelpad = self.parent.MainParamDict['xLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
             self.axes.set_ylabel(tmp_str, labelpad = self.parent.MainParamDict['yLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
 
+        if self.GetPlotParam('show_streamlines'):
+            streamlines.draw_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):
             self.FigWrap.SetCpuDomainLines()
@@ -544,6 +549,10 @@ class DensPanel:
                 self.CbarTickFormatter()
             if self.GetPlotParam('show_shock'):
                 self.shockline_2d.set_xdata([self.parent.shock_loc,self.parent.shock_loc])
+
+        if self.GetPlotParam('show_streamlines'):
+            streamlines.refresh_streamlines(self)
+
         if self.GetPlotParam('show_cpu_domains'):
             self.FigWrap.UpdateCpuDomainLines()
 
@@ -623,8 +632,8 @@ class DensSettings(Tk.Toplevel):
 
         self.wm_title('Dens Plot (%d,%d) Settings' % self.parent.FigWrap.pos)
         self.parent = parent
-        frm = ttk.Frame(self)
-        frm.pack(fill=Tk.BOTH, expand=True)
+        self.frm = ttk.Frame(self)
+        self.frm.pack(fill=Tk.BOTH, expand=True)
         self.protocol('WM_DELETE_WINDOW', self.OnClosing)
         self.bind('<Return>', self.TxtEnter)
 
@@ -634,8 +643,8 @@ class DensSettings(Tk.Toplevel):
         self.InterpolVar.set(self.parent.GetPlotParam('interpolation')) # default value
         self.InterpolVar.trace('w', self.InterpolChanged)
 
-        ttk.Label(frm, text="Interpolation Method:").grid(row=0, column = 2)
-        InterplChooser = ttk.OptionMenu(frm, self.InterpolVar, self.parent.GetPlotParam('interpolation'), *tuple(self.parent.InterpolationMethods))
+        ttk.Label(self.frm, text="Interpolation Method:").grid(row=0, column = 2)
+        InterplChooser = ttk.OptionMenu(self.frm, self.InterpolVar, self.parent.GetPlotParam('interpolation'), *tuple(self.parent.InterpolationMethods))
         InterplChooser.grid(row =0, column = 3, sticky = Tk.W + Tk.E)
 
         # Create the OptionMenu to chooses the Chart Type:
@@ -643,14 +652,14 @@ class DensSettings(Tk.Toplevel):
         self.ctypevar.set(self.parent.chartType) # default value
         self.ctypevar.trace('w', self.ctypeChanged)
 
-        ttk.Label(frm, text="Choose Chart Type:").grid(row=0, column = 0)
-        ctypeChooser = ttk.OptionMenu(frm, self.ctypevar, self.parent.chartType, *tuple(self.parent.ChartTypes))
+        ttk.Label(self.frm, text="Choose Chart Type:").grid(row=0, column = 0)
+        ctypeChooser = ttk.OptionMenu(self.frm, self.ctypevar, self.parent.chartType, *tuple(self.parent.ChartTypes))
         ctypeChooser.grid(row =0, column = 1, sticky = Tk.W + Tk.E)
 
 
         self.TwoDVar = Tk.IntVar(self) # Create a var to track whether or not to plot in 2-D
         self.TwoDVar.set(self.parent.GetPlotParam('twoD'))
-        cb = ttk.Checkbutton(frm, text = "Show in 2-D",
+        cb = ttk.Checkbutton(self.frm, text = "Show in 2-D",
                 variable = self.TwoDVar,
                 command = self.Change2d)
         cb.grid(row = 1, sticky = Tk.W)
@@ -660,10 +669,10 @@ class DensSettings(Tk.Toplevel):
         self.DensTypeVar  = Tk.IntVar()
         self.DensTypeVar.set(self.parent.GetPlotParam('dens_type'))
 
-        ttk.Label(frm, text='Choose Density:').grid(row = 2, sticky = Tk.W)
+        ttk.Label(self.frm, text='Choose Density:').grid(row = 2, sticky = Tk.W)
 
         for i in range(len(self.DensList)):
-            ttk.Radiobutton(frm,
+            ttk.Radiobutton(self.frm,
                 text=self.DensList[i],
                 variable=self.DensTypeVar,
                 command = self.RadioField,
@@ -673,7 +682,7 @@ class DensSettings(Tk.Toplevel):
         # Control whether or not Cbar is shown
         self.CbarVar = Tk.IntVar()
         self.CbarVar.set(self.parent.GetPlotParam('show_cbar'))
-        cb = ttk.Checkbutton(frm, text = "Show Color bar",
+        cb = ttk.Checkbutton(self.frm, text = "Show Color bar",
                         variable = self.CbarVar,
                         command = self.CbarHandler)
         cb.grid(row = 6, sticky = Tk.W)
@@ -681,7 +690,7 @@ class DensSettings(Tk.Toplevel):
         # show shock
         self.ShockVar = Tk.IntVar()
         self.ShockVar.set(self.parent.GetPlotParam('show_shock'))
-        cb = ttk.Checkbutton(frm, text = "Show Shock",
+        cb = ttk.Checkbutton(self.frm, text = "Show Shock",
                         variable = self.ShockVar,
                         command = self.ShockVarHandler)
         cb.grid(row = 6, column = 1, sticky = Tk.W)
@@ -689,7 +698,7 @@ class DensSettings(Tk.Toplevel):
         # Normalize Density Var
         self.NormDVar = Tk.IntVar()
         self.NormDVar.set(self.parent.GetPlotParam('normalize_density'))
-        cb = ttk.Checkbutton(frm, text = "Normalize to ppc0",
+        cb = ttk.Checkbutton(self.frm, text = "Normalize to ppc0",
                         variable = self.NormDVar,
                         command = self.NormPPCHandler)
         cb.grid(row = 7, sticky = Tk.W)
@@ -697,14 +706,14 @@ class DensSettings(Tk.Toplevel):
         # show labels
         self.ShowLabels = Tk.IntVar()
         self.ShowLabels.set(self.parent.GetPlotParam('show_labels'))
-        cb = ttk.Checkbutton(frm, text = "Show Labels 2D",
+        cb = ttk.Checkbutton(self.frm, text = "Show Labels 2D",
                         variable = self.ShowLabels,
                         command = self.LabelHandler)
         cb.grid(row = 7, column = 1, sticky = Tk.W)
         # Control whether or not diverging cmap is used
         self.DivVar = Tk.IntVar()
         self.DivVar.set(self.parent.GetPlotParam('UseDivCmap'))
-        cb = ttk.Checkbutton(frm, text = "Use Diverging Cmap",
+        cb = ttk.Checkbutton(self.frm, text = "Use Diverging Cmap",
                         variable = self.DivVar,
                         command = self.DivHandler)
         cb.grid(row = 8, sticky = Tk.W)
@@ -712,14 +721,14 @@ class DensSettings(Tk.Toplevel):
         # Use full div cmap
         self.StretchVar = Tk.IntVar()
         self.StretchVar.set(self.parent.GetPlotParam('stretch_colors'))
-        cb = ttk.Checkbutton(frm, text = "Symmetric about zero",
+        cb = ttk.Checkbutton(self.frm, text = "Symmetric about zero",
                         variable = self.StretchVar,
                         command = self.StretchHandler)
         cb.grid(row = 9, column = 0, columnspan =2, sticky = Tk.W)
 
         self.CPUVar = Tk.IntVar()
         self.CPUVar.set(self.parent.GetPlotParam('show_cpu_domains'))
-        cb = ttk.Checkbutton(frm, text = "Show CPU domains",
+        cb = ttk.Checkbutton(self.frm, text = "Show CPU domains",
                         variable = self.CPUVar,
                         command = self.CPUVarHandler)
         cb.grid(row = 10, column = 0, sticky = Tk.W)
@@ -729,18 +738,18 @@ class DensSettings(Tk.Toplevel):
         self.cnormvar.set(self.parent.chartType) # default value
         self.cnormvar.trace('w', self.cnormChanged)
 
-        ttk.Label(frm, text="Choose Color Norm:").grid(row=6, column = 2)
-        cnormChooser = ttk.OptionMenu(frm, self.cnormvar, self.parent.GetPlotParam('cnorm_type'), *tuple(['Pow', 'Linear']))
+        ttk.Label(self.frm, text="Choose Color Norm:").grid(row=6, column = 2)
+        cnormChooser = ttk.OptionMenu(self.frm, self.cnormvar, self.parent.GetPlotParam('cnorm_type'), *tuple(['Pow', 'Linear']))
         cnormChooser.grid(row =6, column = 3, sticky = Tk.W + Tk.E)
 
         # Now the gamma of the pow norm
         self.powGamma = Tk.StringVar()
         self.powGamma.set(str(self.parent.GetPlotParam('cpow_num')))
-        ttk.Label(frm, text ='gamma =').grid(row = 7, column = 2, sticky =Tk.E)
-        ttk.Label(frm, text ='If cnorm is Pow =>').grid(row = 8, column = 2,columnspan = 2, sticky =Tk.W)
-        ttk.Label(frm, text ='sign(data)*|data|**gamma').grid(row = 9, column = 2,columnspan = 2, sticky =Tk.E)
+        ttk.Label(self.frm, text ='gamma =').grid(row = 7, column = 2, sticky =Tk.E)
+        ttk.Label(self.frm, text ='If cnorm is Pow =>').grid(row = 8, column = 2,columnspan = 2, sticky =Tk.W)
+        ttk.Label(self.frm, text ='sign(data)*|data|**gamma').grid(row = 9, column = 2,columnspan = 2, sticky =Tk.E)
 
-        self.GammaEnter = ttk.Entry(frm, textvariable=self.powGamma, width=7)
+        self.GammaEnter = ttk.Entry(self.frm, textvariable=self.powGamma, width=7)
         self.GammaEnter.grid(row = 7, column = 3)
 
 
@@ -762,18 +771,20 @@ class DensSettings(Tk.Toplevel):
         self.Zmax.set(str(self.parent.GetPlotParam('v_max')))
 
 
-        cb = ttk.Checkbutton(frm, text ='Set dens min',
+        cb = ttk.Checkbutton(self.frm, text ='Set dens min',
                         variable = self.setZminVar)
         cb.grid(row = 3, column = 2, sticky = Tk.W)
-        self.ZminEnter = ttk.Entry(frm, textvariable=self.Zmin, width=7)
+        self.ZminEnter = ttk.Entry(self.frm, textvariable=self.Zmin, width=7)
         self.ZminEnter.grid(row = 3, column = 3)
 
-        cb = ttk.Checkbutton(frm, text ='Set dens max',
+        cb = ttk.Checkbutton(self.frm, text ='Set dens max',
                         variable = self.setZmaxVar)
         cb.grid(row = 4, column = 2, sticky = Tk.W)
 
-        self.ZmaxEnter = ttk.Entry(frm, textvariable=self.Zmax, width=7)
+        self.ZmaxEnter = ttk.Entry(self.frm, textvariable=self.Zmax, width=7)
         self.ZmaxEnter.grid(row = 4, column = 3)
+
+        streamlines.add_streamline_buttons(self, self.parent, starting_row=11)
 
     def ShockVarHandler(self, *args):
         if self.parent.GetPlotParam('show_shock')== self.ShockVar.get():
@@ -923,6 +934,7 @@ class DensSettings(Tk.Toplevel):
             self.parent.SetPlotParam('set_v_max', self.setZmaxVar.get())
 
     def TxtEnter(self, e):
+        streamlines.streamlines_callback(self, update_plot=True) # not updating plots because FieldsCallback forces an update no matter what
         self.FieldsCallback()
         self.GammaCallback()
 

--- a/src/density_plots.py
+++ b/src/density_plots.py
@@ -413,7 +413,7 @@ class DensPanel:
             self.axes.set_xlabel(r'$x\ [c/\omega_{\rm pe}]$', labelpad = self.parent.MainParamDict['xLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
             self.axes.set_ylabel(tmp_str, labelpad = self.parent.MainParamDict['yLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
 
-        if self.GetPlotParam('show_streamlines'):
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
             streamlines.draw_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):
@@ -550,7 +550,7 @@ class DensPanel:
             if self.GetPlotParam('show_shock'):
                 self.shockline_2d.set_xdata([self.parent.shock_loc,self.parent.shock_loc])
 
-        if self.GetPlotParam('show_streamlines'):
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
             streamlines.refresh_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -151,6 +151,10 @@ class FieldsPanel:
                     if line[1:15] == 'def FieldFunc(':
                         self.f3args = [elm.strip() for elm in line[15:-2].split(',')]
                         self.arrs_needed += self.f3args
+
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
+            streamlines.add_streamline_plot_keys(self)
+
         return self.arrs_needed
 
     def LoadData(self):

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -11,6 +11,7 @@ import matplotlib.colors as mcolors
 import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
 import matplotlib.transforms as mtransforms
+import streamlines
 
 class FieldsPanel:
     # A dictionary of all of the parameters for this plot with the default parameters
@@ -72,6 +73,8 @@ class FieldsPanel:
                        'stretch_colors': False, # If stretch colors is false, then for a diverging cmap the plot ensures -b and b are the same distance from the midpoint of the cmap.
                        'show_cpu_domains': False, # plots lines showing how the CPUs are divvying up the computational region
                        'face_color': 'gainsboro' }
+
+    streamlines.add_streamline_params(plot_param_dict)
 
     gradient =  np.linspace(0, 1, 256)# A way to make the colorbar display better
     gradient = np.vstack((gradient, gradient))
@@ -746,6 +749,9 @@ class FieldsPanel:
         #
         ####
 
+        if self.GetPlotParam('show_streamlines'):
+            streamlines.draw_streamlines(self)
+
         if self.GetPlotParam('show_cpu_domains'):
             self.FigWrap.SetCpuDomainLines()
     def refresh(self):
@@ -921,6 +927,9 @@ class FieldsPanel:
                 self.axes.set_ylabel(r'$y\ [c/\omega_{\rm pe}]$', labelpad = self.parent.MainParamDict['yLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
             if self.parent.MainParamDict['2DSlicePlane'] == 1:
                 self.axes.set_ylabel(r'$z\ [c/\omega_{\rm pe}]$', labelpad = self.parent.MainParamDict['yLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
+
+        if self.GetPlotParam('show_streamlines'):
+            streamlines.refresh_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):
             self.FigWrap.UpdateCpuDomainLines()
@@ -1189,6 +1198,7 @@ class FieldSettings(Tk.Toplevel):
                         command = self.NormFieldHandler)
         cb.grid(row = 7, column = 1, sticky = Tk.W)
 
+        streamlines.add_streamline_buttons(self, self.parent, starting_row=11)
 
     def CbarHandler(self, *args):
         if self.parent.GetPlotParam('show_cbar')== self.CbarVar.get():
@@ -1494,6 +1504,7 @@ class FieldSettings(Tk.Toplevel):
                 self.parent.SetPlotParam('show_z', self.ShowZVar.get())
 
     def TxtEnter(self, e):
+        streamlines.streamlines_callback(self, update_plot=False) # not updating plots because FieldsCallback forces an update no matter what
         self.FieldsCallback()
         self.GammaCallback()
 

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -749,7 +749,7 @@ class FieldsPanel:
         #
         ####
 
-        if self.GetPlotParam('show_streamlines'):
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
             streamlines.draw_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):
@@ -928,7 +928,7 @@ class FieldsPanel:
             if self.parent.MainParamDict['2DSlicePlane'] == 1:
                 self.axes.set_ylabel(r'$z\ [c/\omega_{\rm pe}]$', labelpad = self.parent.MainParamDict['yLabelPad'], color = 'black', size = self.parent.MainParamDict['AxLabelSize'])
 
-        if self.GetPlotParam('show_streamlines'):
+        if self.GetPlotParam('show_streamlines') and self.GetPlotParam('twoD'):
             streamlines.refresh_streamlines(self)
 
         if self.GetPlotParam('show_cpu_domains'):

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+"""This file contains the functions to control and generate the magnetic
+streamline overlays. Due to the highly coupled nature of the classes that
+control the figures these functions have many side effects. This isn't ideal
+but it's better than having this code duplicated in half a dozen different
+places.
+"""
+
+import tkinter as Tk
+import numpy as np
+import matplotlib
+
+
+def add_streamline_params(param_dictionary):
+    """Add data to the parameter dictionary for controlling the streamlines.
+
+    Parameters
+    ----------
+    param_dictionary : dict
+        The dictionary to add elements to.
+    """
+    param_dictionary["show_streamlines"] = False
+    param_dictionary["streamlines_fields"] = "bxby"
+    param_dictionary["streamlines_stride"] = 10
+    param_dictionary["streamlines_density"] = 1
+    param_dictionary["streamlines_color"] = "black"
+
+
+def add_streamline_buttons(settings, panel, starting_row):
+    """Add the various buttons, fields, etc for the streamlines to the settings pane
+
+    Parameters
+    ----------
+    settings :
+        The settings object for the panel being drawn in
+    panel :
+        The Panel object the streamlines are being drawn in
+    starting_row :
+        The row to start adding settings at
+    """
+
+    # Label
+    Tk.ttk.Label(settings.frm, text="Streamline Settings:").grid(
+        row=starting_row, sticky=Tk.W
+    )
+
+    # Create checkbox to toggle the streamlines
+    settings.show_streamlines = Tk.BooleanVar()
+    settings.show_streamlines.set(settings.parent.GetPlotParam("show_streamlines"))
+    Tk.ttk.Checkbutton(
+        settings.frm,
+        text="Display Streamlines",
+        variable=settings.show_streamlines,
+        command=lambda: __show_streamline_handler(settings, panel),
+    ).grid(row=starting_row + 1, sticky=Tk.W)
+
+    # Choose which streamlines to display
+    settings.streamlines_fields = Tk.StringVar()
+    settings.streamlines_fields.set(settings.parent.GetPlotParam("streamlines_fields"))
+    Tk.ttk.Radiobutton(
+        settings.frm,
+        text="Bx/By",
+        variable=settings.streamlines_fields,
+        value="bxby",
+        command=lambda: __update_parameter(
+            settings, "streamlines_fields", settings.streamlines_fields.get()
+        ),
+    ).grid(row=starting_row + 2, sticky=Tk.W)
+    Tk.ttk.Radiobutton(
+        settings.frm,
+        text="By/Bz",
+        variable=settings.streamlines_fields,
+        value="bybz",
+        command=lambda: __update_parameter(
+            settings, "streamlines_fields", settings.streamlines_fields.get()
+        ),
+    ).grid(row=starting_row + 3, sticky=Tk.W)
+    Tk.ttk.Radiobutton(
+        settings.frm,
+        text="Bx/Bz",
+        variable=settings.streamlines_fields,
+        value="bxbz",
+        command=lambda: __update_parameter(
+            settings, "streamlines_fields", settings.streamlines_fields.get()
+        ),
+    ).grid(row=starting_row + 4, sticky=Tk.W)
+
+    # Set stride
+    settings.streamlines_stride = Tk.IntVar(
+        value=settings.parent.GetPlotParam("streamlines_stride")
+    )
+    Tk.ttk.Label(settings.frm, text="Stride:").grid(row=starting_row + 5, sticky=Tk.W)
+    Tk.ttk.Entry(settings.frm, textvariable=settings.streamlines_stride, width=7).grid(
+        row=starting_row + 5, sticky=Tk.E
+    )
+
+    # Set line density
+    settings.streamlines_density = Tk.DoubleVar(
+        value=settings.parent.GetPlotParam("streamlines_density")
+    )
+    Tk.ttk.Label(settings.frm, text="Line Density:").grid(
+        row=starting_row + 6, sticky=Tk.W
+    )
+    Tk.ttk.Entry(settings.frm, textvariable=settings.streamlines_density, width=7).grid(
+        row=starting_row + 6, sticky=Tk.E
+    )
+
+    # Set line color
+    settings.streamlines_color = Tk.StringVar(
+        value=settings.parent.GetPlotParam("streamlines_color")
+    )
+    Tk.ttk.Label(settings.frm, text="Line Color:").grid(
+        row=starting_row + 7, sticky=Tk.W
+    )
+    Tk.ttk.Entry(settings.frm, textvariable=settings.streamlines_color, width=7).grid(
+        row=starting_row + 7, sticky=Tk.E
+    )
+
+
+def __show_streamline_handler(settings, panel):
+    """Handle what happens when the `show_streamlines` button is toggledself.
+
+    Parameters
+    ----------
+    settings :
+        The settings object for the panel being drawn in
+    panel :
+        The Panel object the streamlines are being drawn in
+    """
+    # Write value to the settings dictionary
+    settings.parent.SetPlotParam(
+        "show_streamlines", settings.show_streamlines.get(), update_plot=False
+    )
+    # Either create the streamlines or remove them depending on the state of the checkbox
+    if settings.parent.GetPlotParam("show_streamlines"):
+        draw_streamlines(panel)
+    else:
+        remove_streamlines(panel)
+
+    # Update everything
+    settings.parent.parent.canvas.draw()
+    settings.parent.parent.canvas.get_tk_widget().update_idletasks()
+
+
+def __update_parameter(settings, param_name, value):
+    settings.parent.SetPlotParam(param_name, value, update_plot=True)
+
+
+def streamlines_callback(settings, update_plot=True):
+    # Don't update the plot if there's no streamplot active
+    if not settings.parent.GetPlotParam('show_streamlines'):
+        update_plot = False
+
+    # Handle streamline stride
+    if settings.streamlines_stride.get() != settings.streamlines_stride:
+        settings.parent.SetPlotParam(
+            "streamlines_stride",
+            settings.streamlines_stride.get(),
+            update_plot=update_plot,
+        )
+
+    # Handle streamline density
+    if settings.streamlines_density.get() != settings.streamlines_density:
+        settings.parent.SetPlotParam(
+            "streamlines_density",
+            settings.streamlines_density.get(),
+            update_plot=update_plot,
+        )
+
+    # Handle streamline color
+    if settings.streamlines_color.get() != settings.streamlines_color:
+        settings.parent.SetPlotParam(
+            "streamlines_color",
+            settings.streamlines_color.get(),
+            update_plot=update_plot,
+        )
+
+
+def draw_streamlines(panel):
+    """Draw streamlines.
+
+    Parameters
+    ----------
+    panel :
+        The Panel object the streamlines are being drawn in
+    """
+    # Logging and start timer
+    print("drawing streamlines")
+    from timeit import default_timer as timer
+
+    start = timer()
+
+    # Get settings from panel
+    fields = panel.GetPlotParam("streamlines_fields")
+    stride = panel.GetPlotParam("streamlines_stride")
+    line_density = panel.GetPlotParam("streamlines_density")
+    line_color = panel.GetPlotParam("streamlines_color")
+
+    # Grab the data, use aliases to make it easier to work with
+    if fields == "bxby":
+        bx_name, by_name = "bx", "by"
+    elif fields == "bybz":
+        bx_name, by_name = "by", "bz"
+    elif fields == "bxbz":
+        bx_name, by_name = "bx", "bz"
+    else:
+        raise ValueError(
+            f"Improper fields value of {fields} passed to draw_streamlines. "
+        )
+    bx = panel.parent.DataDict[bx_name][0, ::stride, ::stride]
+    by = panel.parent.DataDict[by_name][0, ::stride, ::stride]
+
+    # Create meshgrid
+    x_min, x_max = panel.FigWrap.graph.axes.get_xlim()
+    y_min, y_max = panel.FigWrap.graph.axes.get_ylim()
+    coords_x = np.linspace(x_min, x_max, bx.shape[1])
+    coords_y = np.linspace(y_min, y_max, bx.shape[0])
+    coords_x, coords_y = np.meshgrid(coords_x, coords_y)
+
+    # Draw plots
+    start_plot = timer()
+    panel.FigWrap.streamlines = panel.FigWrap.graph.axes.streamplot(
+        coords_x, coords_y, bx, by, density=line_density, color=line_color
+    )
+
+    # Report timing
+    end = timer()
+    overall = end - start
+    streamplot = end - start_plot
+    print(
+        f"Time to generate streamlines: {overall:.3f}s. "
+        f"Time for `plt.streamplot` only: {streamplot:.3f}s. "
+        f"{streamplot/overall*100:.2f}% of time spent in `plt.streamplot`."
+    )
+
+
+def refresh_streamlines(panel):
+    """Refresh the streamlines. Since the StreamplotSet object has no set_data() method we will just clear the streamlines and redraw them
+
+    Parameters
+    ----------
+    panel :
+        The panel object the streamlines are being drawn in
+    """
+    print("refreshing streamlines")
+    remove_streamlines(panel)
+    draw_streamlines(panel)
+
+
+def remove_streamlines(panel):
+    """Remove streamlines.
+
+    Parameters
+    ----------
+    panel :
+        The Panel object that the streamlines are being drawn in
+    """
+    # Remove lines
+    panel.FigWrap.streamlines.lines.remove()
+
+    # Remove arrows
+    for artist in panel.FigWrap.graph.axes.get_children():
+        if isinstance(artist, matplotlib.patches.FancyArrowPatch):
+            artist.remove()

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -148,7 +148,7 @@ def __update_parameter(settings, param_name, value):
 
 def streamlines_callback(settings, update_plot=True):
     # Don't update the plot if there's no streamplot active
-    if not settings.parent.GetPlotParam('show_streamlines'):
+    if not settings.parent.GetPlotParam("show_streamlines"):
         update_plot = False
 
     # Handle streamline stride
@@ -184,12 +184,6 @@ def draw_streamlines(panel):
     panel :
         The Panel object the streamlines are being drawn in
     """
-    # Logging and start timer
-    print("drawing streamlines")
-    from timeit import default_timer as timer
-
-    start = timer()
-
     # Get settings from panel
     fields = panel.GetPlotParam("streamlines_fields")
     stride = panel.GetPlotParam("streamlines_stride")
@@ -218,19 +212,8 @@ def draw_streamlines(panel):
     coords_x, coords_y = np.meshgrid(coords_x, coords_y)
 
     # Draw plots
-    start_plot = timer()
     panel.FigWrap.streamlines = panel.FigWrap.graph.axes.streamplot(
         coords_x, coords_y, bx, by, density=line_density, color=line_color
-    )
-
-    # Report timing
-    end = timer()
-    overall = end - start
-    streamplot = end - start_plot
-    print(
-        f"Time to generate streamlines: {overall:.3f}s. "
-        f"Time for `plt.streamplot` only: {streamplot:.3f}s. "
-        f"{streamplot/overall*100:.2f}% of time spent in `plt.streamplot`."
     )
 
 
@@ -242,7 +225,6 @@ def refresh_streamlines(panel):
     panel :
         The panel object the streamlines are being drawn in
     """
-    print("refreshing streamlines")
     remove_streamlines(panel)
     draw_streamlines(panel)
 

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -40,8 +40,8 @@ def add_streamline_buttons(settings, panel, starting_row):
     """
 
     # Label
-    Tk.ttk.Label(settings.frm, text="Streamline Settings:").grid(
-        row=starting_row, sticky=Tk.W
+    Tk.ttk.Label(settings.frm, text="Streamline Settings: (2D only)").grid(
+        row=starting_row, columnspan=2, sticky=Tk.W
     )
 
     # Create checkbox to toggle the streamlines

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -11,6 +11,15 @@ import numpy as np
 import matplotlib
 
 
+def add_streamline_plot_keys(panel):
+    if panel.parent.MainParamDict["2DSlicePlane"] == 0:  # x-y plane
+        panel.arrs_needed.append("bx")
+        panel.arrs_needed.append("by")
+    elif panel.parent.MainParamDict["2DSlicePlane"] == 1:  # x-z plane
+        panel.arrs_needed.append("bx")
+        panel.arrs_needed.append("bz")
+
+
 def add_streamline_params(param_dictionary):
     """Add data to the parameter dictionary for controlling the streamlines.
 


### PR DESCRIPTION
# Summary

This PR adds the option to overlay magnetic streamlines (streamplots) over the Field and Density plots. In the respective settings panels for those two plot types there is a new `Streamline Settings:` section that controls the presence of streamlines along with the following options:

- `Stride:` controls the subsampling of the data plotted. The magnetic fields are subsampled with a stride, default 10, to speed up plotting. Setting `stride=1` turns off subsampling. In my testing, a stride of 1 took 10-15s to plot and a stride of 10 took 300-400ms. Increasing the stride past 10 did not yield significant improvements though this will likely vary by dataset
- `Line Density` controls the density of streamlines plotted, defaults to 1
- `Line Color` sets the color of the streamline. Any color string that matplotlib would normally expect should work

## Note

Modifying the opacity of the streamlines is possible. Unfortunately, the `StreamplotSet` object that `matplotlib.axes.Axes.streamplot` returns is not as fully featured as returned objects from most other plotting functions. As a result setting the opacity is non-trivial and bears the chance of impacting other elements of the plot, though that is unlikely in this particular application. If there's a need to add an opacity option I can do so.

## Cloning Instructions

if you already have that repo cloned locally then

```bash
$ cd path/to/bob-iseult
$ git fetch origin
$ git checkout --track origin/master-streamplot
```
if not
```bash
$ git clone git@github.com:bcaddy/Iseult.git bob-iseult
$ cd bob-iseult
$ git checkout --track origin/master-streamplot
```

Resolves #11 