### PR TITLE
Load v2 density as number density instead of mass density

### DIFF
--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -124,10 +124,10 @@ def test___handle_tristan_v2_datasets():
                 # catch the cases with warnings
                 if dataset_name in ['gamma0']:
                     with pytest.warns(UserWarning):
-                        result = data_loading.__handle_tristan_v2(data_dir, file, dataset_name, slice(None), None)
+                        result = data_loading.__handle_tristan_v2(data_dir/name, file, dataset_name, slice(None), None)
                 else:
-                    result = data_loading.__handle_tristan_v2(data_dir, file, dataset_name, slice(None), None)
-                    assert np.array_equiv(result, fiducial_data[name][i]), \
+                    result = data_loading.__handle_tristan_v2(data_dir/name, file, dataset_name, slice(None), None)
+                    assert np.array_equiv(result, fiducial_data[name][i].astype(np.float32)), \
                         f'Datasets {dataset_name} in file {name} do not match expectations.' \
                         f'Expected {fiducial_data[name][i] = } got {result = }'
 


### PR DESCRIPTION
Tristan v1 saves number densities and Tristan v2 saves mass densities. This adds some logic to convert loaded Tristan v2 mass densities into number densities.

Fixes #45