### PR TITLE
Fix #47 & Improve Streamline Performance

### DIFF
--- a/src/density_plots.py
+++ b/src/density_plots.py
@@ -937,7 +937,7 @@ class DensSettings(Tk.Toplevel):
             self.parent.SetPlotParam('set_v_max', self.setZmaxVar.get())
 
     def TxtEnter(self, e):
-        streamlines.streamlines_callback(self, update_plot=True) # not updating plots because FieldsCallback forces an update no matter what
+        streamlines.streamlines_callback(self, update_plot=True)
         self.FieldsCallback()
         self.GammaCallback()
 

--- a/src/fields_plots.py
+++ b/src/fields_plots.py
@@ -1508,7 +1508,7 @@ class FieldSettings(Tk.Toplevel):
                 self.parent.SetPlotParam('show_z', self.ShowZVar.get())
 
     def TxtEnter(self, e):
-        streamlines.streamlines_callback(self, update_plot=False) # not updating plots because FieldsCallback forces an update no matter what
+        streamlines.streamlines_callback(self, update_plot=False)
         self.FieldsCallback()
         self.GammaCallback()
 

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -106,7 +106,7 @@ def __show_streamline_handler(settings, panel):
     """
     # Write value to the settings dictionary
     settings.parent.SetPlotParam(
-        "show_streamlines", settings.show_streamlines.get(), update_plot=False
+        "show_streamlines", settings.show_streamlines.get(), update_plot=False, NeedsRedraw=True
     )
     # Either create the streamlines or remove them depending on the state of the checkbox
     if settings.parent.GetPlotParam("show_streamlines"):

--- a/src/streamlines.py
+++ b/src/streamlines.py
@@ -108,10 +108,9 @@ def __show_streamline_handler(settings, panel):
     settings.parent.SetPlotParam(
         "show_streamlines", settings.show_streamlines.get(), update_plot=False, NeedsRedraw=True
     )
-    # Either create the streamlines or remove them depending on the state of the checkbox
-    if settings.parent.GetPlotParam("show_streamlines"):
-        draw_streamlines(panel)
-    else:
+
+    # Remove streamlines if the checkbox is unchecked
+    if not settings.parent.GetPlotParam("show_streamlines"):
         remove_streamlines(panel)
 
     # Update everything
@@ -129,7 +128,9 @@ def streamlines_callback(settings, update_plot=True):
         update_plot = False
 
     # Handle streamline stride
-    if settings.streamlines_stride.get() != settings.streamlines_stride:
+    if settings.streamlines_stride.get() != settings.parent.plot_param_dict['streamlines_stride']:
+        settings.parent.plot_param_dict['streamlines_stride'] = settings.streamlines_stride.get()
+
         settings.parent.SetPlotParam(
             "streamlines_stride",
             settings.streamlines_stride.get(),
@@ -137,7 +138,9 @@ def streamlines_callback(settings, update_plot=True):
         )
 
     # Handle streamline density
-    if settings.streamlines_density.get() != settings.streamlines_density:
+    if settings.streamlines_density.get() != settings.parent.plot_param_dict['streamlines_density']:
+        settings.parent.plot_param_dict['streamlines_density'] = settings.streamlines_density.get()
+
         settings.parent.SetPlotParam(
             "streamlines_density",
             settings.streamlines_density.get(),
@@ -145,7 +148,9 @@ def streamlines_callback(settings, update_plot=True):
         )
 
     # Handle streamline color
-    if settings.streamlines_color.get() != settings.streamlines_color:
+    if settings.streamlines_color.get() != settings.parent.plot_param_dict['streamlines_color']:
+        settings.parent.plot_param_dict['streamlines_color'] = settings.streamlines_color.get()
+
         settings.parent.SetPlotParam(
             "streamlines_color",
             settings.streamlines_color.get(),


### PR DESCRIPTION
This fixes #47 and fixes a few spots where the streamlines would be unnecessarily computed and plotted multiple times in a row; this should reduce the time to plot streamlines by 2-3x in many cases.

Credit to @pcrumley for figuring out what the fix for Issue #47 was.