### PR TITLE
Fix Issue #49

### DIFF
--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -34,7 +34,7 @@ def __detect_tristan_data_version(file: h5py.File) -> int:
     elif any(key in file for key in v2_keys):
         return 2
     else:
-        raise ValueError('Data file format is not supported. If this is a data file from Tristan v1 or v2 please submit a bug report.')
+        raise ValueError(f"Format of the file '{file.filename}' is not supported. If this is a data file from Tristan v1 or v2 please submit a bug report.")
 # =============================================================================
 
 # =============================================================================

--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -27,7 +27,7 @@ def __detect_tristan_data_version(file: h5py.File) -> int:
     # The fields to query were chosen only because they don't exist in the other version of Tristan
     #  Files:  particles fields   spectra  paramater: extra for improved matching on some dataset
     v1_keys = ('che',   'densi', 'gamma', 'acool')
-    v2_keys = ('ind_1', 'dens1', 'ebins', 'algorithm:c', 'ind_5')
+    v2_keys = ('ind_1', 'ind_2', 'ind_5', 'dens1', 'ebins', 'algorithm:c')
 
     if any(key in file for key in v1_keys):
         return 1


### PR DESCRIPTION
This fixes #49 by adding the appropriate key to the list of keys used to determine which Tristan version the data was generated with.

I also updated the error message to be a little clearer and indicate which file is unable to be identified.